### PR TITLE
Speckle_Toolkit: issue6and7-Tidy up-History config in Push

### DIFF
--- a/SpeckleToolkit/Speckle_Adapter/CRUD/Create.cs
+++ b/SpeckleToolkit/Speckle_Adapter/CRUD/Create.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using BH.oM;
+using SpeckleCore;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,97 +8,100 @@ using System.Threading.Tasks;
 
 namespace BH.Adapter.Speckle
 {
-  public partial class SpeckleAdapter
-  {
-    /***************************************************/
-    /**** Adapter overload method                   ****/
-    /***************************************************/
+    public partial class SpeckleAdapter
+    {
+        /***************************************************/
+        /**** Adapter overload method                   ****/
+        /***************************************************/
 
-    //protected override bool Create<T>( IEnumerable<T> objects, bool replaceAll = false )
-    //{
-    //  bool success = true;        //boolean returning if the creation was successfull or not
+        protected override bool Create<T>(IEnumerable<T> objects, bool replaceAll = false) 
+        {
+            IEnumerable<object> newObjects = (IEnumerable<object>) objects; //hacky; assumes T is always a reference type. Should be no problem anyway
 
-    //  success = CreateCollection( objects as dynamic );
+            List<SpeckleObject> objs_serialized = SpeckleCore.Converter.Serialise(newObjects);
+            SpeckleLayerDefault.ObjectCount += objects.Count();
+            SpeckleStreamDefault.Objects.AddRange(objs_serialized);
 
-    //  UpdateViews()             //If there exists a command for updating the views is the software call it now:
+            var updateResponse = SpeckleClient.StreamUpdateAsync(SpeckleClient.Stream.StreamId, SpeckleStreamDefault).Result;
+            SpeckleClient.BroadcastMessage("stream", SpeckleClient.Stream.StreamId, new { eventType = "update-global" });
 
-    //  return success;             //Finally return if the creation was successful or not
+            return true;            
 
-    //}
+        }
 
-    ///***************************************************/
-    ///**** Private methods                           ****/
-    ///***************************************************/
+        ///***************************************************/
+        ///**** Private methods                           ****/
+        ///***************************************************/
 
-    //private bool CreateCollection( IEnumerable<Bar> bars )
-    //{
-    //  //Code for creating a collection of bars in the software
-
-
-    //  foreach ( Bar bar in bars )
-    //  {
-    //    //Tip: if the NextId method has been implemented you can get the id to be used for the creation out as (cast into applicable type used by the software):
-    //    object barId = bar.CustomData[ AdapterId ];
-    //    //If also the default implmentation for the DependencyTypes is used,
-    //    //one can from here get the id's of the subobjects by calling (cast into applicable type used by the software): 
-    //    object startNodeId = bar.StartNode.CustomData[ AdapterId ];
-    //    object endNodeId = bar.EndNode.CustomData[ AdapterId ];
-    //    object SecPropId = bar.SectionProperty.CustomData[ AdapterId ];
-    //  }
+        //private bool CreateCollection( IEnumerable<Bar> bars )
+        //{
+        //  //Code for creating a collection of bars in the software
 
 
-    //  throw new NotImplementedException();
-    //}
-
-    ///***************************************************/
-
-    //private bool CreateCollection( IEnumerable<Node> nodes )
-    //{
-    //  //Code for creating a collection of nodes in the software
-
-    //  foreach ( Node node in nodes )
-    //  {
-    //    //Tip: if the NextId method has been implemented you can get the id to be used for the creation out as (cast into applicable type used by the software):
-    //    object nodeId = node.CustomData[ AdapterId ];
-    //  }
-
-    //  throw new NotImplementedException();
-    //}
-
-    ///***************************************************/
-
-    //private bool CreateCollection( IEnumerable<ISectionProperty> sectionProperties )
-    //{
-    //  //Code for creating a collection of section properties in the software
-
-    //  foreach ( ISectionProperty sectionProperty in sectionProperties )
-    //  {
-    //    //Tip: if the NextId method has been implemented you can get the id to be used for the creation out as (cast into applicable type used by the software):
-    //    object secPropId = sectionProperty.CustomData[ AdapterId ];
-    //    //If also the default implmentation for the DependencyTypes is used,
-    //    //one can from here get the id's of the subobjects by calling (cast into applicable type used by the software): 
-    //    object materialId = sectionProperty.Material.CustomData[ AdapterId ];
-    //  }
-
-    //  throw new NotImplementedException();
-    //}
-
-    ///***************************************************/
-
-    //private bool CreateCollection( IEnumerable<Material> materials )
-    //{
-    //  //Code for creating a collection of materials in the software
-
-    //  foreach ( Material material in materials )
-    //  {
-    //    //Tip: if the NextId method has been implemented you can get the id to be used for the creation out as (cast into applicable type used by the software):
-    //    object materialId = material.CustomData[ AdapterId ];
-    //  }
-
-    //  throw new NotImplementedException();
-    //}
+        //  foreach ( Bar bar in bars )
+        //  {
+        //    //Tip: if the NextId method has been implemented you can get the id to be used for the creation out as (cast into applicable type used by the software):
+        //    object barId = bar.CustomData[ AdapterId ];
+        //    //If also the default implmentation for the DependencyTypes is used,
+        //    //one can from here get the id's of the subobjects by calling (cast into applicable type used by the software): 
+        //    object startNodeId = bar.StartNode.CustomData[ AdapterId ];
+        //    object endNodeId = bar.EndNode.CustomData[ AdapterId ];
+        //    object SecPropId = bar.SectionProperty.CustomData[ AdapterId ];
+        //  }
 
 
-    /***************************************************/
-  }
+        //  throw new NotImplementedException();
+        //}
+
+        ///***************************************************/
+
+        //private bool CreateCollection( IEnumerable<Node> nodes )
+        //{
+        //  //Code for creating a collection of nodes in the software
+
+        //  foreach ( Node node in nodes )
+        //  {
+        //    //Tip: if the NextId method has been implemented you can get the id to be used for the creation out as (cast into applicable type used by the software):
+        //    object nodeId = node.CustomData[ AdapterId ];
+        //  }
+
+        //  throw new NotImplementedException();
+        //}
+
+        ///***************************************************/
+
+        //private bool CreateCollection( IEnumerable<ISectionProperty> sectionProperties )
+        //{
+        //  //Code for creating a collection of section properties in the software
+
+        //  foreach ( ISectionProperty sectionProperty in sectionProperties )
+        //  {
+        //    //Tip: if the NextId method has been implemented you can get the id to be used for the creation out as (cast into applicable type used by the software):
+        //    object secPropId = sectionProperty.CustomData[ AdapterId ];
+        //    //If also the default implmentation for the DependencyTypes is used,
+        //    //one can from here get the id's of the subobjects by calling (cast into applicable type used by the software): 
+        //    object materialId = sectionProperty.Material.CustomData[ AdapterId ];
+        //  }
+
+        //  throw new NotImplementedException();
+        //}
+
+        ///***************************************************/
+
+        //private bool CreateCollection( IEnumerable<Material> materials )
+        //{
+        //  //Code for creating a collection of materials in the software
+
+        //  foreach ( Material material in materials )
+        //  {
+        //    //Tip: if the NextId method has been implemented you can get the id to be used for the creation out as (cast into applicable type used by the software):
+        //    object materialId = material.CustomData[ AdapterId ];
+        //  }
+
+        //  throw new NotImplementedException();
+        //}
+
+
+        /***************************************************/
+    }
 }

--- a/SpeckleToolkit/Speckle_Adapter/CRUD/Read.cs
+++ b/SpeckleToolkit/Speckle_Adapter/CRUD/Read.cs
@@ -10,62 +10,62 @@ namespace BH.Adapter.Speckle
 {
   public partial class SpeckleAdapter
   {
-    /***************************************************/
-    /**** Adapter overload method                   ****/
-    /***************************************************/
-    //protected override IEnumerable<IBHoMObject> Read( Type type, IList ids )
-    //{
-    //  //Choose what to pull out depending on the type. Also see example methods below for pulling out bars and dependencies
-    //  if ( type == typeof( Node ) )
-    //    return ReadNodes( ids as dynamic );
-    //  else if ( type == typeof( Bar ) )
-    //    return ReadBars( ids as dynamic );
-    //  else if ( type == typeof( ISectionProperty ) || type.GetInterfaces().Contains( typeof( ISectionProperty ) ) )
-    //    return ReadSectionProperties( ids as dynamic );
-    //  else if ( type == typeof( Material ) )
-    //    return ReadMaterials( ids as dynamic );
+        /***************************************************/
+        /**** Adapter overload method                   ****/
+        /***************************************************/
+        protected override IEnumerable<IBHoMObject> Read(Type type, IList ids)
+        {
+            ////Choose what to pull out depending on the type. Also see example methods below for pulling out bars and dependencies
+            //if (type == typeof(Node))
+            //    return ReadNodes(ids as dynamic);
+            //else if (type == typeof(Bar))
+            //    return ReadBars(ids as dynamic);
+            //else if (type == typeof(ISectionProperty) || type.GetInterfaces().Contains(typeof(ISectionProperty)))
+            //    return ReadSectionProperties(ids as dynamic);
+            //else if (type == typeof(Material))
+            //    return ReadMaterials(ids as dynamic);
 
-    //  return null;
-    //}
+            return new List<IBHoMObject>();
+        }
 
-    /***************************************************/
-    /**** Private specific read methods             ****/
-    ///***************************************************/
+        /***************************************************/
+        /**** Private specific read methods             ****/
+        ///***************************************************/
 
-    ////The List<string> in the methods below can be changed to a list of any type of identification more suitable for the toolkit
+        ////The List<string> in the methods below can be changed to a list of any type of identification more suitable for the toolkit
 
-    //private List<Bar> ReadBars( List<string> ids = null )
-    //{
-    //  //Implement code for reading bars
-    //  throw new NotImplementedException();
-    //}
+        //private List<Bar> ReadBars( List<string> ids = null )
+        //{
+        //  //Implement code for reading bars
+        //  throw new NotImplementedException();
+        //}
 
-    ///***************************************/
+        ///***************************************/
 
-    //private List<Node> ReadNodes( List<string> ids = null )
-    //{
-    //  //Implement code for reading nodes
-    //  throw new NotImplementedException();
-    //}
+        //private List<Node> ReadNodes( List<string> ids = null )
+        //{
+        //  //Implement code for reading nodes
+        //  throw new NotImplementedException();
+        //}
 
-    ///***************************************/
+        ///***************************************/
 
-    //private List<ISectionProperty> ReadSectionProperties( List<string> ids = null )
-    //{
-    //  //Implement code for reading section properties
-    //  throw new NotImplementedException();
-    //}
+        //private List<ISectionProperty> ReadSectionProperties( List<string> ids = null )
+        //{
+        //  //Implement code for reading section properties
+        //  throw new NotImplementedException();
+        //}
 
-    ///***************************************/
+        ///***************************************/
 
-    //private List<Material> ReadMaterials( List<string> ids = null )
-    //{
-    //  //Implement code for reading materials
-    //  throw new NotImplementedException();
-    //}
+        //private List<Material> ReadMaterials( List<string> ids = null )
+        //{
+        //  //Implement code for reading materials
+        //  throw new NotImplementedException();
+        //}
 
-    /***************************************************/
+        /***************************************************/
 
 
-  }
+    }
 }

--- a/SpeckleToolkit/Speckle_Adapter/SpeckleAdapter.cs
+++ b/SpeckleToolkit/Speckle_Adapter/SpeckleAdapter.cs
@@ -2,65 +2,117 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using BH.oM.Base;
 using BH.oM.DataManipulation.Queries;
 using SpeckleCore;
 
 namespace BH.Adapter.Speckle
 {
-  public partial class SpeckleAdapter : BHoMAdapter
-  {
-
-    public SpeckleApiClient myClient;
-    public Account myAccount;
-
-    //Add any applicable constructors here, such as linking to a specific file or anything else as well as linking to that file through the (if existing) com link via the API
-    public SpeckleAdapter( SpeckleCore.Account speckleAccount, string streamId )
+    public partial class SpeckleAdapter : BHoMAdapter
     {
-      AdapterId = BH.Engine.Speckle.Convert.AdapterId;   //Set the "AdapterId" to "SoftwareName_id". Generally stored as a constant string in the convert class in the SoftwareName_Engine
+        public SpeckleAdapter(SpeckleCore.Account speckleAccount, string speckleStreamId)
+        {
+            Config.SeparateProperties = true;   //Set to true to push dependant properties of objects before the main objects are being pushed. Example: push nodes before pushing bars
+            Config.MergeWithComparer = false;    //Set to true to use EqualityComparers to merge objects. Example: merge nodes in the same location
+            Config.ProcessInMemory = false;     //Set to false to to update objects in the toolkit during the push
+            Config.CloneBeforePush = false;      //Set to true to clone the objects before they are being pushed through the software. Required if any modifications at all, as adding a software ID is done to the objects
+            Config.UseAdapterId = false;
 
-      Config.SeparateProperties = true;   //Set to true to push dependant properties of objects before the main objects are being pushed. Example: push nodes before pushing bars
-      Config.MergeWithComparer = false;    //Set to true to use EqualityComparers to merge objects. Example: merge nodes in the same location
-      Config.ProcessInMemory = false;     //Set to false to to update objects in the toolkit during the push
-      Config.CloneBeforePush = false;      //Set to true to clone the objects before they are being pushed through the software. Required if any modifications at all, as adding a software ID is done to the objects
-      Config.UseAdapterId = false;
+            AdapterId = BH.Engine.Speckle.Convert.AdapterId;
+            SpeckleStreamId = speckleStreamId;
+            SpeckleAccount = speckleAccount;
+            SpeckleStreamParent = new SpeckleStream() { StreamId = SpeckleStreamId };
 
-      myAccount = speckleAccount;
-      myClient = new SpeckleApiClient() { BaseUrl = myAccount.RestApi, AuthToken=myAccount.Token, Stream = new SpeckleStream() { StreamId = streamId } }; // hacky, but i don't want to rebuild stuff and fiddle dll loading etc.
+            SpeckleClient = new SpeckleApiClient() { BaseUrl = SpeckleAccount.RestApi, AuthToken = SpeckleAccount.Token, Stream = SpeckleStreamParent }; // hacky, but i don't want to rebuild stuff and fiddle dll loading etc.
+            SpeckleClient.SetupWebsocket();
+        }
 
-      myClient.SetupWebsocket();
+
+        public override List<IObject> Push(IEnumerable<IObject> objects, string tag = "", Dictionary<string, object> config = null)
+        {
+            List<IObject> IBHoMObjectsToPush = new List<IObject>(); //has to be IObject even if it's going to collect IBHoMObjects
+            List<IObject> IObjectsToPush = new List<IObject>();
+
+            // Initialize Speckle Layer if not existing
+            if (SpeckleLayerDefault == null)
+            {
+                SpeckleLayerDefault = new Layer() { Name = "Default Layer", OrderIndex = 0, StartIndex = 0, Topology = "", Guid = "c8a58593-7080-450b-96b9-b0158844644b" };
+                SpeckleLayerDefault.ObjectCount = 0;
+
+            }
+
+            // Unless another DefaultStream is specified, use the ParentStream created in the Adapter Constructor
+            if (SpeckleStreamDefault == null)
+                SpeckleStreamDefault = SpeckleStreamParent;
+
+            // Initialize the DefaultStream
+            SpeckleStreamDefault.Layers = new List<Layer>() { SpeckleLayerDefault };
+            SpeckleStreamDefault.Objects = new List<SpeckleObject>(); // --> shit's immutable, yo
+
+            // Parse objects to assign additional properties to them
+            foreach (var o in objects)
+            {
+                dynamic bhomObject = o as IBHoMObject;
+                if (bhomObject != null)
+                {
+                    // Assign SpeckleStreamId to the CustomData of the IBHoMObjects
+                    bhomObject.CustomData["Speckle_StreamId"] = SpeckleStreamId;
+                    IBHoMObjectsToPush.Add(bhomObject);
+                }
+                else
+                {
+                    dynamic IObject = o as IObject;
+                    if (IObject != null)
+                        IObjectsToPush.Add(o);
+                }
+            }
+
+            // Check the config for options
+            // Configure history. By default it's enabled, and it produces "child" streams at every push that correspond to versions.
+            configureHistory(config);
+
+            base.Push(IBHoMObjectsToPush, tag, config);
+            Create(IObjectsToPush as dynamic);
+
+            return IObjectsToPush.Concat(IBHoMObjectsToPush).ToList();
+        }
+
+
+        public override IEnumerable<object> Pull(IQuery query, Dictionary<string, object> config = null)
+        {
+            var response = SpeckleClient.StreamGetObjectsAsync(SpeckleClient.Stream.StreamId, "").Result;
+            return Converter.Deserialise(response.Resources);
+        }
+
+        /***************************************************/
+        /**** Private Helper Methods                    ****/
+        /***************************************************/
+        private void configureHistory(Dictionary<string, object> config = null)
+        {
+            ResponseStreamClone response;
+
+            object enableHistoryObj = null;
+
+            if (config != null)
+                config.TryGetValue("EnableHistory", out enableHistoryObj);
+
+            bool? enableHistory = enableHistoryObj as bool?;
+
+            if (enableHistory != null && enableHistory == true)
+                response = SpeckleClient.StreamCloneAsync(SpeckleClient.Stream.StreamId).Result; //this line enables history
+        }
+
+
+        /***************************************************/
+        /**** Public Properties                         ****/
+        /***************************************************/
+        public SpeckleApiClient SpeckleClient { get; private set; }
+        public string SpeckleStreamId { get; private set; }
+        public Account SpeckleAccount { get; private set; }
+        public SpeckleStream SpeckleStreamParent { get; private set; }
+        public SpeckleStream SpeckleStreamDefault { get; private set; }
+        public SpeckleCore.Layer SpeckleLayerDefault { get; private set; }
+
     }
-
-    // Super naive implementation to get the ball rolling - in theory, this should implement the orchestration methods from gh/dyn senders (which actually should be moved in the core)
-    public override List<IObject> Push( IEnumerable<IObject> objects, string tag = "", Dictionary<string, object> config = null )
-    {
-
-      var converted = SpeckleCore.Converter.Serialise( objects );
-      var defaultLayer = new Layer() { Name = "Default Layer", OrderIndex = 0, StartIndex = 0, ObjectCount = converted.Count, Topology = "", Guid = "c8a58593-7080-450b-96b9-b0158844644b" };
-      var myStream = new SpeckleStream() { Objects = converted, Layers = new List<Layer>() { defaultLayer } };
-
-      var cloneResponse = myClient.StreamCloneAsync( myClient.Stream.StreamId ).Result;
-      var updateResponse = myClient.StreamUpdateAsync( myClient.Stream.StreamId, myStream ).Result;
-      myClient.BroadcastMessage( "stream", myClient.Stream.StreamId, new { eventType = "update-global" } );
-      return objects.ToList();
-    }
-
-    // Again, super naive implementation but does what it says on the tin
-    public override IEnumerable<object> Pull( IQuery query, Dictionary<string, object> config = null )
-    {
-      var response = myClient.StreamGetObjectsAsync( myClient.Stream.StreamId, "" ).Result;
-      return Converter.Deserialise( response.Resources );
-    }
-
-    protected override bool Create<T>( IEnumerable<T> objects, bool replaceAll = false )
-    {
-      throw new NotImplementedException();
-    }
-
-    protected override IEnumerable<IBHoMObject> Read( Type type, IList ids )
-    {
-      throw new NotImplementedException();
-    }
-
-  }
 }

--- a/SpeckleToolkit/Speckle_Adapter/Speckle_Adapter.csproj
+++ b/SpeckleToolkit/Speckle_Adapter/Speckle_Adapter.csproj
@@ -43,6 +43,9 @@
       <HintPath>..\..\..\BHoM\Build\DataManipulation_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Reflection_Engine">
+      <HintPath>..\..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>
+    </Reference>
     <Reference Include="SpeckleCore, Version=1.5.7067.37830, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\AppData\Roaming\McNeel\Rhinoceros\6.0\Plug-ins\Speckle Rhino (512d9705-6f92-49ca-a606-d6d5c1ac6aa2)\1.0.0.0\SpeckleCore.dll</HintPath>

--- a/SpeckleToolkit/Speckle_Adapter/Types/Comparer.cs
+++ b/SpeckleToolkit/Speckle_Adapter/Types/Comparer.cs
@@ -3,48 +3,50 @@ using System.Collections.Generic;
 
 namespace BH.Adapter.Speckle
 {
-  public partial class SpeckleAdapter
-  {
-    /***************************************************/
-    /**** BHoM Adapter Interface                    ****/
-    /***************************************************/
-
-    //Standard implementation of the comparer class.
-    //Compares nodes by distance (down to 3 decimal places -> mm)
-    //Compares Materials, SectionProprties, LinkConstraints, and Property2D by name
-    //Add/remove any type in the dictionary below that you want (or not) a specific comparison method for
-
-    protected override IEqualityComparer<T> Comparer<T>( )
+    public partial class SpeckleAdapter
     {
-      throw new NotImplementedException();
-      //Type type = typeof( T );
+        /***************************************************/
+        /**** BHoM Adapter Interface                    ****/
+        /***************************************************/
 
-      //if ( m_Comparers.ContainsKey( type ) )
-      //{
-      //  return m_Comparers[ type ] as IEqualityComparer<T>;
-      //}
-      //else
-      //{
-      //  return EqualityComparer<T>.Default;
-      //}
+        //Standard implementation of the comparer class.
+        //Compares nodes by distance (down to 3 decimal places -> mm)
+        //Compares Materials, SectionProprties, LinkConstraints, and Property2D by name
+        //Add/remove any type in the dictionary below that you want (or not) a specific comparison method for
 
+        protected override IEqualityComparer<T> Comparer<T>()
+        {
+
+            return EqualityComparer<T>.Default;
+
+            //Type type = typeof(T);
+
+            //if (m_Comparers.ContainsKey(type))
+            //{
+            //    return m_Comparers[type] as IEqualityComparer<T>;
+            //}
+            //else
+            //{
+            //    return EqualityComparer<T>.Default;
+            //}
+
+        }
+
+
+        /***************************************************/
+        /**** Private Fields                            ****/
+        /***************************************************/
+
+        //private static Dictionary<Type, object> m_Comparers = new Dictionary<Type, object>
+        //    {
+        //        {typeof(Node), new BH.Engine.Structure.NodeDistanceComparer(3) },   //The 3 in here sets how many decimal places to look at for node merging. 3 decimal places gives mm precision
+        //        {typeof(ISectionProperty), new BHoMObjectNameOrToStringComparer() },
+        //        {typeof(Material), new BHoMObjectNameComparer() },
+        //        {typeof(LinkConstraint), new BHoMObjectNameComparer() },
+        //        {typeof(Property2D), new BHoMObjectNameComparer() },
+        //    };
+
+
+        /***************************************************/
     }
-
-
-    /***************************************************/
-    /**** Private Fields                            ****/
-    /***************************************************/
-
-    //private static Dictionary<Type, object> m_Comparers = new Dictionary<Type, object>
-    //    {
-    //        {typeof(Node), new BH.Engine.Structure.NodeDistanceComparer(3) },   //The 3 in here sets how many decimal places to look at for node merging. 3 decimal places gives mm precision
-    //        {typeof(ISectionProperty), new BHoMObjectNameOrToStringComparer() },
-    //        {typeof(Material), new BHoMObjectNameComparer() },
-    //        {typeof(LinkConstraint), new BHoMObjectNameComparer() },
-    //        {typeof(Property2D), new BHoMObjectNameComparer() },
-    //    };
-
-
-    /***************************************************/
-  }
 }

--- a/SpeckleToolkit/Speckle_Engine/Convert/AdapterId.cs
+++ b/SpeckleToolkit/Speckle_Engine/Convert/AdapterId.cs
@@ -8,6 +8,6 @@ namespace BH.Engine.Speckle
 {
   public static partial class Convert
   {
-    public const string AdapterId = "SpockleSpackle";
+    public const string AdapterId = "Speckle_id";
   }
 }


### PR DESCRIPTION
### Description

#### History
The `SpeckleStream` can have `children` streams that can effectively be used as "history". **See #7 for details**. History can now be enabled or disabled through the config (enabled by default)
<img src="https://user-images.githubusercontent.com/6352844/59037672-a6080d80-8869-11e9-8f0d-efd0d638d837.png" width="350">

#### Tidy up
Most of push code moved to the Create() method. Push now calls its base implementation.
Ideally this means we can make use of the tags and the whole procedure of the `Replace()` method.
This means that if Speckle allows it (TBC) we could Push only portions of the model via the tags by doing:
- Ask Speckle to clone the stream
- Targeting the cloned stream, delete specific objects from it (**Speckle needs to allow deletion, TBC**)
- Create (upload) only the specific objects being updated

Closes #6.
   
### Issues addressed by this PR
Closes #6 and #7 

### Test files
https://burohappold.sharepoint.com/:u:/s/BHoM/EVKARio_CqNJn1rS1B2dYCoBisqHGlYCTdZdWLQ2zRS74w?e=vNgEhP