### PR TITLE
Update `AssemblyFileVersion` to `3.0.0.0`, `AssemblyVersion` to `3.0.0.0` and removed year from copyright

### DIFF
--- a/Speckle_Adapter/Properties/AssemblyInfo.cs
+++ b/Speckle_Adapter/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration( "" )]
 [assembly: AssemblyCompany( "Buro Happold" )]
 [assembly: AssemblyProduct( "Speckle_Adapter" )]
-[assembly: AssemblyCopyright( "Copyright © Buro Happold 2018" )]
+[assembly: AssemblyCopyright( "Copyright © Buro Happold" )]
 [assembly: AssemblyTrademark( "" )]
 [assembly: AssemblyCulture( "" )]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "2.0.0.0" )]
-[assembly: AssemblyFileVersion( "2.4.0.0" )]
+[assembly: AssemblyVersion( "3.0.0.0" )]
+[assembly: AssemblyFileVersion( "3.0.0.0" )]

--- a/Speckle_Engine/Properties/AssemblyInfo.cs
+++ b/Speckle_Engine/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration( "" )]
 [assembly: AssemblyCompany( "Buro Happold" )]
 [assembly: AssemblyProduct( "Speckle_Engine" )]
-[assembly: AssemblyCopyright( "Copyright © Buro Happold 2018" )]
+[assembly: AssemblyCopyright( "Copyright © Buro Happold" )]
 [assembly: AssemblyTrademark( "" )]
 [assembly: AssemblyCulture( "" )]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "2.0.0.0" )]
-[assembly: AssemblyFileVersion( "2.4.0.0" )]
+[assembly: AssemblyVersion( "3.0.0.0" )]
+[assembly: AssemblyFileVersion( "3.0.0.0" )]


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
 
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #32 

<!-- Add short description of what has been fixed -->

### Test
<!-- Link to test files to validate the proposed changes -->
Make sure that:
- All the .csproj files in the solution have the properties  `AssemblyFileVersion` to `3.0.0.0` and `AssemblyVersion` to `3.0.0.0`.
- The AssemblyCopyright reads `[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]`
