### PR TITLE
Specify `Engine.Speckle.Compute` for ambiguous ref

### DIFF
--- a/Speckle_Adapter/CRUD/Create/CreateIBHoMObjects.cs
+++ b/Speckle_Adapter/CRUD/Create/CreateIBHoMObjects.cs
@@ -45,7 +45,7 @@ namespace BH.Adapter.Speckle
             bhomObject.CustomData["Speckle_StreamId"] = SpeckleStreamId;
 
             // SpeckleObject "container". Top level has geometry representation of BHoM Object, so it can be visualised in the SpeckleViewer. 
-            SpeckleObject speckleObject = Compute.SpeckleRepresentation(bhomObject, config.DisplayOption);
+            SpeckleObject speckleObject = Engine.Speckle.Compute.SpeckleRepresentation(bhomObject, config.DisplayOption);
 
             // If no Speckle representation is found, it will be sent as an "Abstract" SpeckleObject (no visualisation).
             if (speckleObject == null)


### PR DESCRIPTION
VS was throwing a build error

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #70 

<!-- Add short description of what has been fixed -->
Specify `Engine.Speckle.Compute` in `CreateIBHoMObjects.cs`
